### PR TITLE
Made it nicer

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,57 +1,28 @@
 #include <iostream>
-#include <cstring>
 using namespace std;
-
-long long FILL_SIZE;
-void fuckMemory();
-void fuckMemoryWithoutMemset();
 
 int main()
 {
-	int choose;
-	cout << "Start FuckMemory(1)" << endl << "Start FuckMemory without memset - Harmless(2)" << endl;
-	cout << endl << "Choose a mode(Default is \"Start FuckMemory\"): ";
-	choose=getchar();
-	cout << "Type a default memory size(MB): ";
+	cout << "Start FuckMemory (1)" << endl << "Start FuckMemory without fill - Harmless (2)" << endl;
+	cout << endl << "Choose a mode (Default is \"Start FuckMemory\"): ";
+	int choose = getchar();
+
+	long long FILL_SIZE;
+	cout << "Type a default memory size in MB: ";
 	cin >> FILL_SIZE;
-	FILL_SIZE *= 1024*1024;
-	switch(choose)
-	{
-		case '2':
-				fuckMemoryWithoutMemset();break;
-		default:
-				fuckMemory();
-	}
-	return 0;
-}
+	FILL_SIZE *= 1024 * 1024;
 
-void fuckMemoryWithoutMemset()
-{
-	long long memsize;
-	memsize = 0;
-	while(1)
+	long long memsize = 0;
+	while (true)
 	{
-		if(getchar() != '\n')
-		    continue;
-		memsize += FILL_SIZE;
-		char *buf = new char[FILL_SIZE];
-		cout << "Current memsize: " << memsize / 1024 / 1024 << "MB";
-		//getchar();
-	}
-}
-
-void fuckMemory()
-{
-	long long memsize;
-	memsize = 0;
-	while(1)
-	{
-		if(getchar() != '\n')
+		if (getchar() != '\n')
 			continue;
 		memsize += FILL_SIZE;
-		char *buf = new char[FILL_SIZE];
-		memset (buf,rand()%255, FILL_SIZE);
-		cout << "Current memsize: " << memsize / 1024 / 1024 << "MB";
-		//getchar();
+		int *buf = new int[FILL_SIZE >> 2];
+		if (choose != '2')
+			fill(buf, buf + FILL_SIZE >> 2, rand());
+		cout << "Current memsize: " << memsize / 1024 / 1024 << " MB";
 	}
+
+	return 0;
 }


### PR DESCRIPTION
Put some spaces in strings so it looks better.
You don't need a separate function for both versions, you don't even need a separate function for any version to begin with.
memset is a C function, std::fill is a similar function in C++.
rand() is usually of type int, so instead of rand() % 255 (actually it should've been 256 to get values from 0 to 255), just rand() alone can be used instead (rand() is also C, but doing random in C++ would require an additional header).